### PR TITLE
Cálculo do peso cubado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 braspress
 =========
 
-Módulo de frete para a Braspress
+Módulo de frete para a Braspress.
+
+Um *fork* do módulo http://github.com/TadeuRodrigues/braspress, incrementado com algumas funcionalidades:
+
+- *Cálculo do peso cubado*: se os produtos tiverem os atributos *width*, *height* e *length*, será ignorado o peso original do produto e obtido o peso cubado, ou seja, o novo peso é calculado de acordo com as regras de cálculo da Braspress. Multiplica-se os valores da largura, algura e comprimento com a densidade, que é um valor padrão para os modais *rodoviário* (300) e *aéreo* (167).
+
+- *Valor do frete como um percentual sobre o valor do pedido*: é possível definir como valor do frete um percentual sobre o valor da compra ou o retornado pelo *web service* da Braspress. Caso a opção "percentual" seja escolhida, o percentual pode ser configurado em um valor de 0,01 a 99,99%.

--- a/app/code/community/Tadeurodrigues/Braspress/Model/Carrier/Default.php
+++ b/app/code/community/Tadeurodrigues/Braspress/Model/Carrier/Default.php
@@ -172,10 +172,10 @@ class TadeuRodrigues_Braspress_Model_Carrier_Default extends Mage_Shipping_Model
             // record method information
             $method->setMethod($this->_code);
 
-			Mage::log($calFrete->PRAZOENTREGA, null, 'braspress_test.log');
+			Mage::log($calFrete->PRAZO, null, 'braspress_test.log');
 			
 			if($this->getConfigData('delivery_time')){
-				$prazo = $calFrete->PRAZOENTREGA;
+				$prazo = $calFrete->PRAZO;
 				switch($prazo){
 					case 0:
 						$prazomsg = ' entrega imediata';
@@ -196,11 +196,18 @@ class TadeuRodrigues_Braspress_Model_Carrier_Default extends Mage_Shipping_Model
             $method->setMethodTitle($method_name);
 
 			//  Verifica se deve ser calculada uma porcentagem sobre o valor da compra para ser usada como valor do frete  //
+			$min_carrier_valid = $this->getConfigData('min_carrier_active') == 1 &&
+								 ($min_carrier_value = (float)preg_replace(array('|[^\d\.,]|', '|\.|', '|,|'), array('', '', '.'), $this->getConfigData('min_carrier_value'))) && $min_carrier_value > 0.00 &&
+								 ($min_carrier_max_order_value = (float)preg_replace(array('|[^\d\.,]|', '|\.|', '|,|'), array('', '', '.'), $this->getConfigData('min_carrier_max_order_value'))) && $min_carrier_max_order_value > 0.00 &&
+								 $PackageValue <= $min_carrier_max_order_value;
+
 			$percentage_over_order_value = $this->getConfigData('percentage_over_order_value') == 1 &&
 										   ($percentage = (float)preg_replace(array('|[^\d\.,]|', '|\.|', '|,|'), array('', '', '.'), $this->getConfigData('percentage'))) &&
 										   ($percentage > 0 && $percentage < 100);
 
-			if ($percentage_over_order_value) {
+			if ($min_carrier_valid) {
+				$price = (float)number_format($min_carrier_value, 2, '.', '');
+			} elseif ($percentage_over_order_value) {
 				$price = (float)number_format($PackageValue * $percentage / 100, 2, '.', '');
 			} else {
 				//  Formata o valor do frete para float, caso contrário, não grava os centavos  //

--- a/app/code/community/Tadeurodrigues/Braspress/Model/Carrier/Default.php
+++ b/app/code/community/Tadeurodrigues/Braspress/Model/Carrier/Default.php
@@ -12,7 +12,7 @@ class TadeuRodrigues_Braspress_Model_Carrier_Default extends Mage_Shipping_Model
    */
   protected $_code          =   'braspress';
   protected $_url_base_soap =   'http://tracking.braspress.com.br/wscalculafreteisapi.dll/wsdl/IWSCalcFrete?wsdl';
-  protected $_url_base_web	=	'http://www.braspress.com.br/cotacaoXml?param=';
+  protected $_url_base_web	=	'http://tracking.braspress.com.br/trk/trkisapi.dll/PgCalcFrete_XML?param=';
   
   protected $_result        =   null;
   protected $params         =   array();
@@ -30,59 +30,120 @@ class TadeuRodrigues_Braspress_Model_Carrier_Default extends Mage_Shipping_Model
 		return false;
 	}
 
-    if($this->getConfigData('weight_type') == 2){
-        $Weight = $request->getPackageWeight()/10000;
-    }else{
-        $Weight = $request->getPackageWeight();
-    }
-	
 	$quote	=	$this->getQuote();
 	$cart	=	$this->getCart();
-	
-	// cnpj default
-	
+
+	$method = Mage::getModel('shipping/rate_result_method');
+	$method_name = '';
+
+	/*  Calcula o PESO CUBADO, que é a multiplicação das medidas de cada volume com sua quantidade e a densidade estabelecida como padrão por todas as transportadoras brasileiras.
+		Se o PESO CUBADO for maior que o PESO REAL, o peso cubado é enviado para o web service calcular o frete. Caso contrário, o peso real é enviado.
+		Esta é a diferença entre, por exemplo, carregar 10 kg de chumbo e 10 kg de pena. O espaço necessário para carregar o primeiro volume é muito menor que o requerido pelo segundo.  */
+	//  Verifica se os campos "comprimento", "largura" e "altura" existem  //
+	$atributo_comprimento_existe = ($attribute = Mage::getModel('eav/entity_attribute')->loadByCode('catalog_product', 'length')) && ($attribute->getId());
+	$atributo_largura_existe = ($attribute = Mage::getModel('eav/entity_attribute')->loadByCode('catalog_product', 'width')) && ($attribute->getId());
+	$atributo_altura_existe = ($attribute = Mage::getModel('eav/entity_attribute')->loadByCode('catalog_product', 'height')) && ($attribute->getId());
+
+	$peso_cubado_habilita = $atributo_comprimento_existe && $atributo_largura_existe && $atributo_altura_existe;
+	//  =================================================================  //
+
+	if ($peso_cubado_habilita) {
+		//  Verifica a unidade de medida a ser utilizada  //
+		switch ($this->getConfigData('measure_type')) {
+			case 'mm': $unidade_medida = 0.001; break;
+			case 'cm': $unidade_medida = 0.01; break;
+			case 'dm': $unidade_medida = 0.1; break;
+			case 'm':
+			default: $unidade_medida = 1; break;
+		}
+		//  ============================================  //
+
+		//  Verifica a densidade a ser utilizada, de acordo com o modal. Rodoviário = 300 Aéreo = 167  //
+		$densidade = $this->getConfigData('modal_type') == 'R' ? 300 : 167;
+
+		$peso_cubado = $peso_real = $peso_total = 0.00;
+
+		//  Calcula o peso cubado de cada item da sacola  //
+		foreach (Mage::getSingleton('checkout/session')->getQuote()->getAllItems() as $item) {
+			//  Carrega os dados do produto  //
+			$product = Mage::getSingleton('catalog/product')->load($item->getProduct()->getId());
+
+			//  Calcula a multiplicação do comprimento com a largura e com a altura, depois arredonda com duas casas decimais, pois uma precisão maior afeta negativamente o valor do frete  //
+			$peso_cubado_volume = (float)number_format((float)number_format($product->getData('length') * $unidade_medida, 3, '.', '') *
+													   (float)number_format($product->getData('width') * $unidade_medida, 3, '.', '') *
+													   (float)number_format($product->getData('height') * $unidade_medida, 3, '.', ''), 2, '.', '');
+			//  ===========================================================================================================================================================================  //
+
+			if ($peso_cubado_habilita && $peso_cubado_volume > 0.00) {
+				//  Multiplica o valor acima com a densidade, obtendo o peso cubado do volume  //
+				$peso_cubado_volume = (float)number_format($peso_cubado_volume * $densidade, 3, '.', '');
+
+				//  Multiplica o peso cubado do volume com a quantidade, obtendo o peso cubado total do item  //
+				$peso_cubado += (float)number_format($peso_cubado_volume * $item->getQty(), 3, '.', '');
+			} else {
+				//  Desabilita o peso cubado  //
+				$peso_cubado = 0.00;
+				$peso_cubado_habilita = false;
+				//  ========================  //
+			}
+
+			//  Multiplica o peso real do produto com a quantidade, obtendo o peso real do item  //
+			$peso_real += (float)number_format($item->getWeight() * $item->getQty(), 3, '.', '');
+		}
+		//  ============================================  //
+
+		//  Se o peso cubado é maior que o real, pega o cubado para enviar ao web service, caso contrário, pega o real  //
+		$Weight = $peso_cubado_habilita && $peso_cubado > $peso_real ? $peso_cubado : $peso_real;
+	} else {
+		//  Pega o peso total dos itens  //
+		$Weight = $request->getPackageWeight();
+	}
+	//  ================================================================================================================================================================================  //
+
+	//  Se a configuração do peso for em gramas, transforma o peso total para quilos  //
+    if ($this->getConfigData('weight_type') == 2) $Weight /= 1000;
+
+	//  Verifica o CNPJ do destinatário  //
 	switch($this->getConfigData('use_default')){
 		case 0:
 			$cnpjdes = $quote->getData("customer_taxvat");
 			break;
+
 		case 1:
 			$cnpjdes = $this->getConfigData('cnpj');
 			break;
+
 		case 2:
 			$cnpjdes = $this->getConfigData('cnpj_default');
 			break;
-			
+
 		default:
 			$cnpjdes = $quote->getData("customer_taxvat");
-		
+			break;
 	}
+	//  ===============================  //
 
-	$this->params = array(
-    "cnpj"          =>   preg_replace( '/[^0-9]/', '', $this->getConfigData('cnpj') ),
-    "emporigem"		=>	 2,
-    "ceporigem"     =>   preg_replace( '/[^0-9]/', '', Mage::getStoreConfig('shipping/origin/postcode', $this->getStore())),
-    "cepdestino"    =>   preg_replace( '/[^0-9]/', '', $request->getDestPostcode() ),
-    "cnpjrem"       =>   preg_replace( '/[^0-9]/', '', $this->getConfigData('cnpj') ),
-    "cnpjdes"       =>   preg_replace( '/[^0-9]/', '', $cnpjdes),
-    "tipofrete"     =>   $this->getConfigData('shipping_type'),
-    "peso"          =>   $Weight,
-    "valornf"       =>   number_format($request->getPackageValue(), 2, '.', ''),
-    "volume"        =>   $cart->getItemsCount(),
-    "modal"         =>   $this->getConfigData('modal_type')
-	);
-	
-	
-	if($this->getConfigData('access_type') == 1){
-	    $calFrete = $this->CalculaFrete();
-		
-	}else{
-		$params = implode(',', $this->params);
-		
-		$calFrete = simplexml_load_file($this->_url_base_web.$params);
-	}                                     
+	//  Constroi os parâmetros da chamada ao web service  //
+	$this->params = array("cnpj"       => preg_replace( '/[^0-9]/', '', $this->getConfigData('cnpj') ),
+						  "emporigem"  => 2,
+						  "ceporigem"  => preg_replace( '/[^0-9]/', '', Mage::getStoreConfig('shipping/origin/postcode', $this->getStore())),
+						  "cepdestino" => preg_replace( '/[^0-9]/', '', $request->getDestPostcode() ),
+						  "cnpjrem"    => preg_replace( '/[^0-9]/', '', $this->getConfigData('cnpj') ),
+						  "cnpjdes"    => preg_replace( '/[^0-9]/', '', $cnpjdes),
+						  "tipofrete"  => $this->getConfigData('shipping_type'),
+						  "peso"       => $Weight,
+						  "valornf"    => number_format($request->getPackageValue(), 2, '.', ''),
+						  "volume"     => $cart->getItemsCount(),
+						  "modal"      => $this->getConfigData('modal_type'));
+	//  ================================================  //
 
+	//  Chama o web service  //
+	$calFrete = $this->getConfigData('access_type') == 1 ? $this->CalculaFrete() : simplexml_load_file($this->_url_base_web . implode(',', $this->params));
+
+	//  Inicializa o resultado da função  //
     $this->_result = Mage::getModel('shipping/rate_result');
-	
+
+	//  Cria o log da chamada deste método  //
 	if($this->getConfigData('debug')){
 		//Mage::log($request->getData(), null, 'request.log');
 		//Mage::log($quote->getData(), null, 'quote.log');
@@ -92,19 +153,17 @@ class TadeuRodrigues_Braspress_Model_Carrier_Default extends Mage_Shipping_Model
 		Mage::log("--------RESPOSTA-------------------", null, 'braspress.log');
 		Mage::log($calFrete, null, 'braspress.log');
 		Mage::log("-----------------------------------", null, 'braspress.log');
-		
-		
-    //Mage::log($quote->getData(),null,'teste1.log');        // order data
-    //Mage::log(Mage::helper('checkout')->getQuote()->getShippingAddress()->getData(),null,'teste2.log'); // shipping data
-	//Mage::log(Mage::helper('tax'), null, 'tax.log');	
+
+		//Mage::log($quote->getData(),null,'teste1.log');        // order data
+		//Mage::log(Mage::helper('checkout')->getQuote()->getShippingAddress()->getData(),null,'teste2.log'); // shipping data
+		//Mage::log(Mage::helper('tax'), null, 'tax.log');	
 	}
+	//  ==================================  //
     
     if($calFrete->MSGERRO != "OK"){
         $this->_throwError('specificerrmsg', $calFrete->MSGERRO, __LINE__);  
     }else{
         if($calFrete->TOTALFRETE > (float) 0 ){
-            $method = Mage::getModel('shipping/rate_result_method');
-            
             $method->setCarrier($this->_code);
             $method->setCarrierTitle($this->getConfigData('title'));
          
@@ -117,7 +176,7 @@ class TadeuRodrigues_Braspress_Model_Carrier_Default extends Mage_Shipping_Model
 				$prazo = $calFrete->PRAZO;
 				switch($prazo){
 					case 0:
-						$prazomsg = ' entrega imedita';
+						$prazomsg = ' entrega imediata';
 					break;
 					case 1:
 						$prazomsg = ' prazo de 1 dia';
@@ -127,15 +186,16 @@ class TadeuRodrigues_Braspress_Model_Carrier_Default extends Mage_Shipping_Model
 					break;
 				}
 				
-				$method_name = $this->getConfigData('method_name').$prazomsg;
+				$method_name .= $this->getConfigData('method_name').$prazomsg;
 			}else{
-				$method_name = $this->getConfigData('method_name');
+				$method_name .= $this->getConfigData('method_name');
 			}
-		
+
             $method->setMethodTitle($method_name);
-            
-            $method->setPrice($calFrete->TOTALFRETE);
-         
+
+			//  Formata o valor do frete para float, caso contrário, não grava os centavos  //
+            $method->setPrice((float)preg_replace(array('|[^\d\.,]|', '|\.|', '|,|'), array('', '', '.'), $calFrete->TOTALFRETE));
+
             // add this rate to the result
             $this->_result->append($method);
         }

--- a/app/code/community/Tadeurodrigues/Braspress/Model/Carrier/Default.php
+++ b/app/code/community/Tadeurodrigues/Braspress/Model/Carrier/Default.php
@@ -173,7 +173,7 @@ class TadeuRodrigues_Braspress_Model_Carrier_Default extends Mage_Shipping_Model
 			Mage::log($calFrete->PRAZOENTREGA, null, 'braspress_test.log');
 			
 			if($this->getConfigData('delivery_time')){
-				$prazo = $calFrete->PRAZO;
+				$prazo = $calFrete->PRAZOENTREGA;
 				switch($prazo){
 					case 0:
 						$prazomsg = ' entrega imediata';

--- a/app/code/community/Tadeurodrigues/Braspress/Model/Source/MeasureType.php
+++ b/app/code/community/Tadeurodrigues/Braspress/Model/Source/MeasureType.php
@@ -1,0 +1,13 @@
+<?php
+class TadeuRodrigues_Braspress_Model_Source_MeasureType
+{
+    public function toOptionArray()
+    {
+        return array(
+            array('value' => 'm', 'label' => 'Metros (m)'),
+            array('value' => 'dm', 'label' => 'Decímetros (dm)'),
+            array('value' => 'cm', 'label' => 'Centímetros (cm)'),
+            array('value' => 'mm', 'label' => 'Milímetros (mm)'),
+        );
+    }
+}

--- a/app/code/community/Tadeurodrigues/Braspress/controllers/Adminhtml/BraspressController.php
+++ b/app/code/community/Tadeurodrigues/Braspress/controllers/Adminhtml/BraspressController.php
@@ -21,7 +21,7 @@
 
 class Tadeurodrigues_Braspress_Adminhtml_BraspressController extends Mage_Adminhtml_Controller_Action
 {
-	 protected $_url_base_web	=	'http://www.braspress.com.br/cotacaoXml?param=';
+	 protected $_url_base_web	=	'http://tracking.braspress.com.br/trk/trkisapi.dll/PgCalcFrete_XML?param=';
 	  
     /**
      * Return some checking result

--- a/app/code/community/Tadeurodrigues/Braspress/etc/config.xml
+++ b/app/code/community/Tadeurodrigues/Braspress/etc/config.xml
@@ -85,6 +85,8 @@
                     <specificerrmsg>Houve um problema interno.</specificerrmsg>
                     <use_default>0</use_default>
                     <cnpj_default>02049076000137</cnpj_default>
+					<percentage_over_order_value>0</percentage_over_order_value>
+					<percentage>0</percentage>
                     <handling_type>R</handling_type>
             </braspress>
         </carriers>

--- a/app/code/community/Tadeurodrigues/Braspress/etc/config.xml
+++ b/app/code/community/Tadeurodrigues/Braspress/etc/config.xml
@@ -85,6 +85,9 @@
                     <specificerrmsg>Houve um problema interno.</specificerrmsg>
                     <use_default>0</use_default>
                     <cnpj_default>02049076000137</cnpj_default>
+					<min_carrier_active>0</min_carrier_active>
+					<min_carrier_value>0</min_carrier_value>
+					<min_carrier_max_order_value>0</min_carrier_max_order_value>
 					<percentage_over_order_value>0</percentage_over_order_value>
 					<percentage>0</percentage>
                     <handling_type>R</handling_type>

--- a/app/code/community/Tadeurodrigues/Braspress/etc/system.xml
+++ b/app/code/community/Tadeurodrigues/Braspress/etc/system.xml
@@ -44,11 +44,39 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </method_name>
+                        <min_carrier_active translate="label">
+                            <label>Ativar Valor Mínimo de Frete?</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>60</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Escolha se deve ser adotado um valor de frete mínimo sobre o valor do pedido (Sim) ou o determinado pela Braspress (Não).]]></comment>
+                        </min_carrier_active>
+                        <min_carrier_value translate="label">
+                            <label>Valor Mínimo de Frete</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>70</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Quando o valor do frete deve ser um mínimo sobre o valor do pedido (somente números e vírgula). Valor deve maior que 0,00.]]></comment>
+                        </min_carrier_value>
+                        <min_carrier_max_order_value translate="label">
+                            <label>Valor Máximo do Pedido</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>80</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Quando o valor do frete deve ser um mínimo sobre o valor do pedido (somente números e vírgula). Valor deve maior que 0,00.]]></comment>
+                        </min_carrier_max_order_value>
                         <percentage_over_order_value translate="label">
                             <label>Valor do Frete Deve Ser um Percentual Sobre o Valor do Pedido?</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>60</sort_order>
+                            <sort_order>90</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -57,16 +85,16 @@
 						<percentage translate="label">
                             <label>Porcentagem (%)</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>70</sort_order>
+                            <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment><![CDATA[Quando o valor do frete deve ser um percentual sobre o valor do pedido (somente números e vírgula). Valor deve ser de 0,01 e 99,99.]]></comment>
                         </percentage>
-                       <cnpj translate="label">
+                        <cnpj translate="label">
                             <label>CNPJ da Loja</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>80</sort_order>
+                            <sort_order>110</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -74,7 +102,7 @@
                         <use_default translate="label">
                             <label>usar CNPJ para o cálculo</label>
                             <frontend_type>select</frontend_type>
-                            <sort_order>82</sort_order>
+                            <sort_order>111</sort_order>
                             <source_model>braspress/source_cnpjDefault</source_model>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -83,6 +111,7 @@
 						<validation translate="label comment">
                             <label>Validation</label>
                             <button_label>Validation</button_label>
+                            <sort_order>112</sort_order>
                             <frontend_model>braspress/adminhtml_system_config_Validation</frontend_model>
                             <comment>
                             	Teste para verificar a autorização do CNPJ junto a Braspress.
@@ -92,12 +121,11 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <sort_order>82</sort_order>
                         </validation>
                         <cnpj_default>
                         	<label>CNPJ Padrão</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>83</sort_order>
+                            <sort_order>113</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -109,7 +137,7 @@
                             <label>Tipo de Acesso</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_accessType</source_model>
-                            <sort_order>85</sort_order>
+                            <sort_order>114</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -118,7 +146,7 @@
                             <label>Exibir Prazo</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>86</sort_order>
+                            <sort_order>115</sort_order>
                             <!--<depends>
                             	<access_type>1</access_type>
                             </depends> -->
@@ -130,7 +158,7 @@
                             <label>Tipo de Frete</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_shippingType</source_model>
-                            <sort_order>90</sort_order>
+                            <sort_order>120</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -139,7 +167,7 @@
                             <label>Modal</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_modalType</source_model>
-                            <sort_order>100</sort_order>
+                            <sort_order>130</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -148,7 +176,7 @@
                             <label>Peso</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_weightType</source_model>
-                            <sort_order>110</sort_order>
+                            <sort_order>140</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -157,7 +185,7 @@
                             <label>Unidade de Medida dos Produtos</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_measureType</source_model>
-                            <sort_order>120</sort_order>
+                            <sort_order>150</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>

--- a/app/code/community/Tadeurodrigues/Braspress/etc/system.xml
+++ b/app/code/community/Tadeurodrigues/Braspress/etc/system.xml
@@ -120,6 +120,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </weight_type>
+                        <measure_type translate="label">
+                            <label>Unidade de Medida dos Produtos</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>braspress/source_measureType</source_model>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </measure_type>
                         <sallowspecific translate="label">
                             <label>Ship to Applicable Countries</label>
                             <frontend_type>select</frontend_type>

--- a/app/code/community/Tadeurodrigues/Braspress/etc/system.xml
+++ b/app/code/community/Tadeurodrigues/Braspress/etc/system.xml
@@ -44,10 +44,29 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </method_name>
+                        <percentage_over_order_value translate="label">
+                            <label>Valor do Frete Deve Ser um Percentual Sobre o Valor do Pedido?</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>60</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Escolha se o valor do frete deve ser um percentual sobre o valor do pedido (Sim) ou o determinado pela Braspress (Não).]]></comment>
+                        </percentage_over_order_value>
+						<percentage translate="label">
+                            <label>Porcentagem (%)</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>70</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Quando o valor do frete deve ser um percentual sobre o valor do pedido (somente números e vírgula). Valor deve ser de 0,01 e 99,99.]]></comment>
+                        </percentage>
                        <cnpj translate="label">
                             <label>CNPJ da Loja</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>60</sort_order>
+                            <sort_order>80</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -55,16 +74,30 @@
                         <use_default translate="label">
                             <label>usar CNPJ para o cálculo</label>
                             <frontend_type>select</frontend_type>
-                            <sort_order>62</sort_order>
+                            <sort_order>82</sort_order>
                             <source_model>braspress/source_cnpjDefault</source_model>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </use_default>                        
+                        </use_default>
+						<validation translate="label comment">
+                            <label>Validation</label>
+                            <button_label>Validation</button_label>
+                            <frontend_model>braspress/adminhtml_system_config_Validation</frontend_model>
+                            <comment>
+                            	Teste para verificar a autorização do CNPJ junto a Braspress.
+                            	OBS: se deixa o CNPJ vazio o sistema ira apenas verificar o acesso.
+                            	NÂO É NECESSARIO SALVAR
+                            </comment>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <sort_order>82</sort_order>
+                        </validation>
                         <cnpj_default>
                         	<label>CNPJ Padrão</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>63</sort_order>
+                            <sort_order>83</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -76,7 +109,7 @@
                             <label>Tipo de Acesso</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_accessType</source_model>
-                            <sort_order>65</sort_order>
+                            <sort_order>85</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -85,7 +118,7 @@
                             <label>Exibir Prazo</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>66</sort_order>
+                            <sort_order>86</sort_order>
                             <!--<depends>
                             	<access_type>1</access_type>
                             </depends> -->
@@ -97,7 +130,7 @@
                             <label>Tipo de Frete</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_shippingType</source_model>
-                            <sort_order>70</sort_order>
+                            <sort_order>90</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -106,7 +139,7 @@
                             <label>Modal</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_modalType</source_model>
-                            <sort_order>80</sort_order>
+                            <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -115,7 +148,7 @@
                             <label>Peso</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_weightType</source_model>
-                            <sort_order>90</sort_order>
+                            <sort_order>110</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -124,7 +157,7 @@
                             <label>Unidade de Medida dos Produtos</label>
                             <frontend_type>select</frontend_type>
                             <source_model>braspress/source_measureType</source_model>
-                            <sort_order>100</sort_order>
+                            <sort_order>120</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -186,21 +219,6 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </debug>
-			
-			            <validation translate="label comment">
-                            <label>Validation</label>
-                            <button_label>Validation</button_label>
-                            <frontend_model>braspress/adminhtml_system_config_Validation</frontend_model>
-                            <comment>
-                            	Teste para verificar a autorização do CNPJ junto a Braspress.
-                            	OBS: se deixa o CNPJ vazio o sistema ira apenas verificar o acesso.
-                            	NÂO É NECESSARIO SALVAR
-                            </comment>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <sort_order>62</sort_order>
-                        </validation>
                     </fields>
                 </braspress>
             </groups>

--- a/app/code/community/Tadeurodrigues/Braspress/etc/system.xml
+++ b/app/code/community/Tadeurodrigues/Braspress/etc/system.xml
@@ -4,7 +4,7 @@
     <carriers>
         <groups>
             <braspress translate="label" module="shipping">
-                <label>TadeuRodrigues - Braspress</label>
+                <label>Braspress</label>
                 <frontend_type>text</frontend_type>
                 <sort_order>13</sort_order>
                 <show_in_default>1</show_in_default>


### PR DESCRIPTION
Cálculo do peso cubado. Se os campos "width", "height" e "length" estiverem presentes no produto, é feita a multiplicação dos valores destes campos com a densidade padrão, de acordo com o modal (rodoviário = 300, aéreo = 167).

Alterado URL do web service para suportar pesos acima de 1.000 kg.
